### PR TITLE
Performance enhancement

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -38,7 +38,8 @@ function loop() {
     var query = {
       date: {'$lt': (Date.now() - properties.gcTimeout)},
       retry: {'$lte': properties.gcRetryLimit},
-      err: {'$exists': false}
+      err: {'$exists': false},
+      removalTime: {$exists:false}
     };
     var options = {sort: [['retry', 'asc'], ['date', 'asc']]};
     var stream = db.collection(properties.collection)
@@ -100,9 +101,9 @@ function replay(item, done) {
   var to = hubiquitus.utils.aid.bare(req.to);
   hubiquitus.send(req.from, to, req.content, properties.gcReplayTimeout, function (err) {
     if (!err) {
-      db.collection(properties.collection).remove({_id: item._id}, function (err) {
+      db.collection(properties.collection).update({_id: item._id}, {'$set': {removalTime: new Date()}}, function (err) {
         if (err) {
-          logger.error('failed to remove replayed req from queue, may be processed twice !', {item: item, err: err});
+          logger.error('failed to set removalTime for replayed req from queue, may be processed twice !', {item: item, err: err});
         }
         done && done();
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubiquitus-qos",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "repository": {
     "type": "git",
     "url": "https://git@github.com:hubiquitus-addons/hubiquitus-qos"


### PR DESCRIPTION
When dst container is on pressure, message can be queued in req_in middleware but re-emmited because container is not reponding.
In such case, we try to insert a message with an already existing _id. We now make an upsert to deal with this case instead of logging a message and cancelling message.

Also avoid deleting messages but update messages with  a removalTime field and add a TTL index on this field.